### PR TITLE
Fix translation list regex

### DIFF
--- a/djangogirls_usbgenerator/generator.py
+++ b/djangogirls_usbgenerator/generator.py
@@ -77,7 +77,7 @@ def yes_no(message, function):
 def list_tutorial_languages():
     """Create a list with all the languages available for the tutorial"""
     r = requests.get("https://www.gitbook.com/download/pdf/book/djangogirls/djangogirls-tutorial")
-    tutorials = re.findall(r"\?lang=(.{2})\">([^<]*)<", r.text)
+    tutorials = re.findall(r"\?lang=(.{2})\".*?>(.*?)<", r.text)
     return dict(tutorials)
 
 


### PR DESCRIPTION
I think perhaps the markup changed - it was coming up with an empty translation list when I tried it.
I also changed the regex to use non-greedy qualifiers to make it a little clearer.
