### PR TITLE
Fix tutorial PDF download crashing because the Content-Length header is missing

### DIFF
--- a/djangogirls_usbgenerator/generator.py
+++ b/djangogirls_usbgenerator/generator.py
@@ -59,7 +59,7 @@ def download_file(address, folder):
         name = params["filename"]
     else:
         name = address.split("/")[-1]
-    total_length = int(r.headers.get('content-length'))
+    total_length = int(r.headers.get('content-length', 0))
     download_file_path = os.path.join(folder, name)
     with open(download_file_path, "wb") as f:
         expected_size = (total_length / 1024) + 1


### PR DESCRIPTION
This is more of a bug report than a proper fix, but I thought I'd propose it nonetheless.

The generator script fails on the first step, because the `Content-Length` header is missing from the tutorial PDF responses:

```python
### TypeError if `content-length` is not  defined.
total_length = int(r.headers.get('content-length'))
```

Full stack trace:

<details>

```
Do you want to download the tutorial?: y
Translations available:
cs: Czech, en: English, es: Spanish, fr: French, hu: Hungarian, it: Italian, ko: Korean, pl: Polish, pt: Portuguese, ru: Russian, sk: Slovak, tr: Turkish, uk: Ukrainian, zh: Chinese
Please, enter your choice (2 letters language code). If multiple choices, use space as a separator.
: en
Traceback (most recent call last):
  File "./djangogirls_usbgenerator/generator.py", line 242, in <module>
    download_steps()
  File "/Users/thibaud/Dev/forks/djangogirls_usbgenerator/venv/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/thibaud/Dev/forks/djangogirls_usbgenerator/venv/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/thibaud/Dev/forks/djangogirls_usbgenerator/venv/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/thibaud/Dev/forks/djangogirls_usbgenerator/venv/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "./djangogirls_usbgenerator/generator.py", line 239, in download_steps
    do_it("Do you want to download %s?" % label, fn)
  File "./djangogirls_usbgenerator/generator.py", line 77, in yes_no
    function()
  File "./djangogirls_usbgenerator/generator.py", line 104, in tutorial
    download_file(url + lang, "downloads/")
  File "./djangogirls_usbgenerator/generator.py", line 63, in download_file
    total_length = int(r.headers.get('content-length'))
TypeError: int() argument must be a string or a number, not 'NoneType'
```

and HTTP response headers:

```
{'X-Pjax-Version': '16.14.4', 'Via': '1.1 vegur', 'Content-Disposition': 'attachment; filename="djangogirls-tutorial-en.pdf"', 'X-Pjax-Url': '/download/pdf/book/djangogirls/djangogirls-tutorial?lang=en', 'Transfer-Encoding': 'chunked', 'Set-Cookie': 'gitbook:sess=eyJ2YXJpYW50IjowLCJhbm9ueW1vdXNJZCI6ImZhZWI3ZTM0LWYzM2MtNDFhMC1iMGUxLTc1ZDIxMzdiODY3MSJ9; path=/; expires=Tue, 03 Jan 2017 02:13:28 GMT; secure; httponly, gitbook:sess.sig=-4CCqM8TlLPBKYwMMdaWfyZT6PQ; path=/; expires=Tue, 03 Jan 2017 02:13:28 GMT; secure; httponly', 'Server': 'GitBook.com', 'Connection': 'keep-alive', 'Etag': '"5385726a0ae2efdeb46cb580f18185ad",1530917709', 'Date': 'Sun, 04 Dec 2016 02:13:28 GMT', 'X-Frame-Options': 'SAMEORIGIN', 'Content-Type': 'application/pdf'}
```

</details>


Setting `total_length` to 0 as this PR does causes the progress bar to jump directly to 100%, which makes it work, but we lose the benefit of the progress bar. I didn't want to change the code too much, a better fix might be to remove the `length` parameter to `click.progressbar` in this case so the progress bar can at least be used as a "loading indicator".