### PR TITLE
Update django download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ You can choose to download everything or skip some parts. You can choose as many
 - Bootstrap
 - Lobster font
 - Python 3.5.2
-- Django 1.10
+- Django 1.11
 - Sublime Text 2
 - Atom 64bits
 

--- a/djangogirls_usbgenerator/generator.py
+++ b/djangogirls_usbgenerator/generator.py
@@ -148,7 +148,7 @@ def python():
 
 def django():
     create_directory()
-    subprocess.check_call(['pip', 'install', 'django~=1.10', '--download', 'downloads'])
+    subprocess.check_call(['pip', 'download', 'django~=1.11', '-d', 'downloads'])
     print("Django downloaded.")
 
 


### PR DESCRIPTION
  * `pip install --download` not working anymore
  * use later version of django

Solves:
```
Do you want to download Django?: y                                                                                                                    
                                                                                                                                                      
Usage:                                                                                                                                                
  pip install [options] <requirement specifier> [package-index-options] ...                                                                           
  pip install [options] -r <requirements file> [package-index-options] ...                                                                            
  pip install [options] [-e] <vcs project url> ...                                                                                                    
  pip install [options] [-e] <local project path> ...                                                                                                 
  pip install [options] <archive url/path> ...                                                                                                        
                                                                                                                                                      
no such option: --download                                                                                                                            
Traceback (most recent call last):                                                                                                                    
  File "/usr/local/bin/djangogirls_usbgenerator", line 11, in <module>                                                                                
    sys.exit(download_steps())                                                                                  
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__                                                               
    return self.main(*args, **kwargs)                                                                    
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main                                                                      
    rv = self.invoke(ctx)                                                                                                     
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke                                                                    
    return ctx.invoke(self.callback, **ctx.params)                                                                                                
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke                                                                
    return callback(*args, **kwargs)                                                                                                                  
  File "/usr/local/lib/python3.6/site-packages/djangogirls_usbgenerator/generator.py", line 242, in download_steps
    do_it("Do you want to download %s?" % label, fn)                                                                                              
  File "/usr/local/lib/python3.6/site-packages/djangogirls_usbgenerator/generator.py", line 80, in yes_no                                          
    function()                                                                                                                                      
  File "/usr/local/lib/python3.6/site-packages/djangogirls_usbgenerator/generator.py", line 151, in django                                            
    subprocess.check_call(['pip', 'install', 'django~=1.10', '--download', 'downloads'])                                                              
  File "/usr/local/lib/python3.6/subprocess.py", line 291, in check_call                                                                              
    raise CalledProcessError(retcode, cmd)                                                                                                            
subprocess.CalledProcessError: Command '['pip', 'install', 'django~=1.10', '--download', 'downloads']' returned non-zero exit status 2. 
```